### PR TITLE
CI: Add a Windows build compilation action

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,21 @@
+name: Windows compilation
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install QT
+      uses: jurplel/install-qt-action@v2
+    - name: Call qmake
+      run: qmake fhex.pro
+    - name: make
+      run: make
+    - uses: actions/upload-artifact@v1
+      with:
+        name: fhex-master
+        path: .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,6 +29,10 @@ jobs:
       run: |
         call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         python bundle-exe-with-dlls.py
+    - name: WindeployQt
+      shell: cmd
+      run: |
+        windeployqt %BUNDLE_DIR%\fhex.exe
     - uses: actions/upload-artifact@v1
       with:
         name: ${{env.BUNDLE_DIR}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,10 +9,17 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install QT
-      run: choco install qt-sdk-windows-x64-mingw_opengl_seh
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        arch: win64_mingw73
+        modules: qtcharts
     - name: Call qmake
-      run: qmake fhex.pro
+      shell: cmd
+      # Inspired by https://github.com/jurplel/install-qt-action/blob/master/.github/workflows/test.yml
+      run: |
+        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        qmake fhex.pro
     - name: make
       run: make
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,7 @@ name: Windows compilation
 on:
   push:
     branches: master
+  pull_request:
 
 jobs:
   build:
@@ -20,9 +21,15 @@ jobs:
       run: |
         call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         qmake fhex.pro
-    - name: make
+    - name: Compile the project with make
       run: make
+    - name: Bundle the exe file with its DLLs
+      shell: cmd
+      # We will also need visual studio tools to find out the dependencies (dumpbin)
+      run: |
+        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        python bundle-exe-with-dlls.py
     - uses: actions/upload-artifact@v1
       with:
-        name: fhex-master
+        name: ${{env.BUNDLE_DIR}}
         path: .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,8 +11,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install QT
       uses: jurplel/install-qt-action@v2
-    - name: Install MSYS2
-      uses: MSP-Greg/msys2-action@master # You might want to reference a commit hash instead
+    - name: Install MinGW 7.3
+      run: choco install mingw-w64 --version 7.3.0
+      # We use 7.3.0 since it's the supported one: https://doc.qt.io/qt-5/windows.html
     - name: Call qmake
       run: qmake fhex.pro
     - name: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,10 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install QT
-      uses: jurplel/install-qt-action@v2
-    - name: Install MinGW 7.3
-      run: choco install mingw --version 7.3.0
-      # We use 7.3.0 since it's the supported one: https://doc.qt.io/qt-5/windows.html
+      run: choco install qt-sdk-windows-x64-mingw_opengl_seh
     - name: Call qmake
       run: qmake fhex.pro
     - name: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install QT
       uses: jurplel/install-qt-action@v2
+    - name: Install MSYS2
+      uses: MSP-Greg/msys2-action@master # You might want to reference a commit hash instead
     - name: Call qmake
       run: qmake fhex.pro
     - name: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install QT
       uses: jurplel/install-qt-action@v2
     - name: Install MinGW 7.3
-      run: choco install mingw-w64 --version 7.3.0
+      run: choco install mingw --version 7.3.0
       # We use 7.3.0 since it's the supported one: https://doc.qt.io/qt-5/windows.html
     - name: Call qmake
       run: qmake fhex.pro

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,17 +23,19 @@ jobs:
         qmake fhex.pro
     - name: Compile the project with make
       run: make
-    - name: Bundle the exe file with its DLLs
+    - name: Add required MinGW DLLs
       shell: cmd
-      # We will also need visual studio tools to find out the dependencies (dumpbin)
+      # We will also need visual studio tools here to find out the dependencies (dumpbin)
       run: |
         call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         python bundle-exe-with-dlls.py
-    - name: WindeployQt
+    - name: Add QT dependencies with WinDeploy
       shell: cmd
+      # Disabled angle and opengl since we don't do 3D graphics here (yet?)
       run: |
-        windeployqt %BUNDLE_DIR%\fhex.exe
-    - uses: actions/upload-artifact@v1
+        windeployqt %BUNDLE_DIR%\fhex.exe --no-angle --no-opengl-sw
+    - name: Upload the binary artifact
+      uses: actions/upload-artifact@v1
       with:
-        name: ${{env.BUNDLE_DIR}}
-        path: .
+        name: windows-build
+        path: ${{env.BUNDLE_DIR}}

--- a/bundle-exe-with-dlls.py
+++ b/bundle-exe-with-dlls.py
@@ -1,0 +1,42 @@
+import os
+import time
+from shutil import copyfile
+
+# Determine the destination directory
+dest_dir="fhex-{}-{}".format(time.strftime("%Y%m%d%H%M%S"), os.environ['GITHUB_SHA'])
+# Set it as an environment variable (for asset uploading)
+print("::set-env name=BUNDLE_DIR::{}".format(dest_dir))
+
+os.mkdir(dest_dir)
+
+# Copy the executable there
+for file in os.listdir('release'):
+	if file[-4:] != '.exe':
+		continue
+	copyfile("release/{}".format(file), "{}/{}".format(dest_dir, file))
+
+# Now, find out the dependencies the executable need and include them (unless they're from Windows)
+for file in os.listdir(dest_dir):
+	deps = os.popen("dumpbin /DEPENDENTS {}".format(file))
+	print("Found dependencies")
+	print(deps)
+	deps = deps.readlines()
+	print("deps list")
+	print(deps)
+	for dep in deps:
+		dep = dep.strip() # Remove trailing line break and leading spaces
+		print("Dep is {}".format(dep))
+		if dep[-4:] != ".dll":
+			continue
+		# Find the DLL
+		dll_path = os.popen("where {}".format(dep))
+		dll_path = dll_path.readlines()
+		dll_path = dll_path[0].strip()
+		print("dll path is {}", dll_path)
+		# If it's in system 32, it's safe to assume it's provided by Windows
+		if dll_path.lower().startswith("c:\\windows\\system32"):
+			continue
+		copyfile(dll_path, "{}/{}".format(dest_dir, dep))
+		print("Copied {}".format(dep))
+		
+print("All done! The .exe file should work!")		

--- a/bundle-exe-with-dlls.py
+++ b/bundle-exe-with-dlls.py
@@ -17,7 +17,7 @@ for file in os.listdir('release'):
 
 # Now, find out the dependencies the executable need and include them (unless they're from Windows)
 for file in os.listdir(dest_dir):
-	deps = os.popen("dumpbin /DEPENDENTS {}/{}".format(dest_dir, file))
+	deps = os.popen("dumpbin /DEPENDENTS {}\\{}".format(dest_dir, file))
 	print("Found dependencies")
 	print(deps)
 	deps = deps.readlines()

--- a/bundle-exe-with-dlls.py
+++ b/bundle-exe-with-dlls.py
@@ -17,7 +17,7 @@ for file in os.listdir('release'):
 
 # Now, find out the dependencies the executable need and include them (unless they're from Windows)
 for file in os.listdir(dest_dir):
-	deps = os.popen("dumpbin /DEPENDENTS {}".format(file))
+	deps = os.popen("dumpbin /DEPENDENTS {}/{}".format(dest_dir, file))
 	print("Found dependencies")
 	print(deps)
 	deps = deps.readlines()

--- a/bundle-exe-with-dlls.py
+++ b/bundle-exe-with-dlls.py
@@ -4,7 +4,7 @@ from shutil import copyfile
 
 # Determine the destination directory
 dest_dir="fhex-{}-{}".format(time.strftime("%Y%m%d%H%M%S"), os.environ['GITHUB_SHA'])
-# Set it as an environment variable (for asset uploading)
+# Set it as an environment variable (for the next steps)
 print("::set-env name=BUNDLE_DIR::{}".format(dest_dir))
 
 os.mkdir(dest_dir)
@@ -17,26 +17,21 @@ for file in os.listdir('release'):
 
 # Now, find out the dependencies the executable need and include them (unless they're from Windows)
 for file in os.listdir(dest_dir):
-	deps = os.popen("dumpbin /DEPENDENTS {}\\{}".format(dest_dir, file))
-	print("Found dependencies")
-	print(deps)
-	deps = deps.readlines()
-	print("deps list")
+	deps = os.popen("dumpbin /DEPENDENTS {}\\{}".format(dest_dir, file)).readlines()
+	print("Dumpbin reported the following DLLs")
 	print(deps)
 	for dep in deps:
 		dep = dep.strip() # Remove trailing line break and leading spaces
-		print("Dep is {}".format(dep))
 		if dep[-4:] != ".dll":
 			continue
 		# Find the DLL
-		dll_path = os.popen("where {}".format(dep))
-		dll_path = dll_path.readlines()
+		dll_path = os.popen("where {}".format(dep)).readlines()
 		dll_path = dll_path[0].strip()
-		print("dll path is {}", dll_path)
 		# If it's in system 32, it's safe to assume it's provided by Windows
 		if dll_path.lower().startswith("c:\\windows\\system32"):
+			print("Skipping {}", dll_path)
 			continue
 		copyfile(dll_path, "{}/{}".format(dest_dir, dep))
 		print("Copied {}".format(dep))
 		
-print("All done! The .exe file should work!")		
+print("All done! Now, run windeploy to get all QT libraries and you're good to go!")

--- a/src/core/hexeditor.h
+++ b/src/core/hexeditor.h
@@ -1,6 +1,10 @@
 #ifndef HEXEDITOR_H
 #define HEXEDITOR_H
 
+#ifdef __MINGW32__
+#define WINDOWS
+#endif
+
 #include <vector>
 #include <istream>
 #include <fstream>


### PR DESCRIPTION
This adds a new Github action performing a Windows build for every commit pushed to `master` or any fork submitting a pull request. This way, you don't even have to think about compiling the project Windows, since it's already done 😄 

I also added a little tweak to get the project to adapt to the windows environment automatically while not breaking other builds. Note this only works with MinGW, which is supported by Qt.

Fixes #2 